### PR TITLE
Исправление отображения скрытого блока в GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,8 @@ const longpollAttachments = {
 и анализа списка вложений, чтобы в случае необходимости получить сообщение через [API](https://vk.com/dev/messages.getById).
 
 <details>
-<summary>Пример кода для получения массива с названиями вложений</summary>
+<summary markdown="span">Пример кода для получения массива с названиями вложений
+</summary>
 
 ```js
 function getAttachments(data) {

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+kramdown:
+  parse_block_html: true


### PR DESCRIPTION
Потрогать вживую: https://vitalyavolyn.github.io/longpoll-doc/